### PR TITLE
Improve tests coverage

### DIFF
--- a/tests/test_traffic_manager.py
+++ b/tests/test_traffic_manager.py
@@ -1,6 +1,5 @@
 import pytest
 
-from ngraph.lib.algorithms.base import MIN_FLOW
 from ngraph.lib.flow_policy import FlowPolicyConfig
 from ngraph.lib.graph import StrictMultiDiGraph
 from ngraph.network import Link, Network, Node

--- a/tests/workflow/test_capacity_probe.py
+++ b/tests/workflow/test_capacity_probe.py
@@ -1,9 +1,10 @@
-import pytest
-from unittest.mock import MagicMock, call
+from unittest.mock import MagicMock
 
-from ngraph.network import Network, Node, Link
-from ngraph.workflow.capacity_probe import CapacityProbe
+import pytest
+
 from ngraph.lib.algorithms.base import FlowPlacement
+from ngraph.network import Link, Network, Node
+from ngraph.workflow.capacity_probe import CapacityProbe
 
 
 @pytest.fixture
@@ -244,3 +245,9 @@ def test_capacity_probe_probe_reverse(mock_scenario):
     assert "max_flow:[B -> A]" in flows
     assert flows["max_flow:[A -> B]"] == 3.0
     assert flows["max_flow:[B -> A]"] == 3.0
+
+
+def test_capacity_probe_invalid_flow_placement():
+    """Invalid flow_placement string should raise ValueError."""
+    with pytest.raises(ValueError, match="Invalid flow_placement"):
+        CapacityProbe(name="Bad", flow_placement="bogus")


### PR DESCRIPTION
## Summary
- add missing error checks in failure_policy
- add coverage for TrafficManager result summarization
- add invalid config test for CapacityProbe

## Testing
- `ruff check tests/test_failure_policy.py tests/test_traffic_manager.py tests/workflow/test_capacity_probe.py`
- `black --check tests/test_failure_policy.py tests/test_traffic_manager.py tests/workflow/test_capacity_probe.py`
- `isort --check tests/test_failure_policy.py tests/test_traffic_manager.py tests/workflow/test_capacity_probe.py`
- `pytest -q --cov=ngraph --cov-fail-under=85 --cov-report term-missing`
