### PR TITLE
Add vars section to YAML schema and documentation

### DIFF
--- a/docs/reference/api-full.md
+++ b/docs/reference/api-full.md
@@ -10,7 +10,7 @@ For a curated, example-driven API guide, see **[api.md](api.md)**.
 > - **[CLI Reference](cli.md)** - Command-line interface
 > - **[DSL Reference](dsl.md)** - YAML syntax guide
 
-**Generated from source code on:** August 06, 2025 at 21:33 UTC
+**Generated from source code on:** August 07, 2025 at 00:14 UTC
 
 **Modules auto-discovered:** 53
 

--- a/docs/reference/dsl.md
+++ b/docs/reference/dsl.md
@@ -16,6 +16,7 @@ The scenario YAML file is organized around a **core foundation** that defines yo
 
 The main sections of a scenario YAML file work together to define a complete network simulation:
 
+- `vars`: **[Optional]** Defines YAML anchors and variables for reuse throughout the scenario file.
 - `network`: **[Required]** Describes the actual network topology - nodes, links, and their connections.
 - `blueprints`: **[Optional]** Defines reusable network templates that can be instantiated multiple times within the network.
 - `components`: **[Optional]** A library of hardware and optics definitions with attributes like power consumption.
@@ -441,6 +442,37 @@ failure_policy_set:
 - If a `default` policy exists, it will be used when no specific policy is selected
 - If only one policy exists and no `default` is specified, that policy becomes the default
 - Multiple policies allow testing different failure scenarios in the same network
+
+## `vars` - YAML Anchors and Variables
+
+The `vars` section provides a designated space for YAML anchor definitions. YAML anchors (`&name`) and aliases (`*name`) follow the YAML 1.1 specification and are processed by PyYAML during parsing, before NetGraph validation.
+
+**Anchor Types:**
+
+- **Scalar anchors**: Reference primitive values (strings, numbers, booleans)
+- **Sequence anchors**: Reference arrays/lists
+- **Mapping anchors**: Reference objects/dictionaries
+- **Merge keys (`<<`)**: Merge mapping properties with override capability
+
+**Minimal Example:**
+
+```yaml
+vars:
+  default_cap: &cap 10000
+  base_attrs: &attrs {cost: 100, region: "dc1"}
+
+network:
+  nodes:
+    N1: {attrs: {<<: *attrs, capacity: *cap}}
+    N2: {attrs: {<<: *attrs, capacity: *cap, region: "dc2"}}
+```
+
+**Processing Behavior:**
+
+- Anchors are resolved during YAML parsing, before schema validation
+- The `vars` section itself is ignored by NetGraph runtime logic
+- Anchors can be defined in any section, not just `vars`
+- Merge operations follow YAML 1.1 semantics (later keys override earlier ones)
 
 ## `workflow` - Execution Steps
 

--- a/ngraph/scenario.py
+++ b/ngraph/scenario.py
@@ -79,6 +79,7 @@ class Scenario:
         with a default ComponentsLibrary if provided.
 
         Top-level YAML keys can include:
+          - vars
           - blueprints
           - network
           - failure_policy_set
@@ -92,6 +93,7 @@ class Scenario:
         If 'failure_policy_set' is omitted, scenario.failure_policy_set is empty.
         If 'components' is provided, it is merged with default_components.
         If 'seed' is provided, it enables reproducible random operations.
+        If 'vars' is provided, it can contain YAML anchors and aliases for reuse.
         If any unrecognized top-level key is found, a ValueError is raised.
 
         Args:
@@ -115,6 +117,7 @@ class Scenario:
 
         # Ensure only recognized top-level keys are present.
         recognized_keys = {
+            "vars",
             "blueprints",
             "network",
             "failure_policy_set",

--- a/schemas/scenario.json
+++ b/schemas/scenario.json
@@ -5,6 +5,10 @@
   "description": "JSON Schema for NetGraph network scenario YAML files",
   "type": "object",
   "properties": {
+    "vars": {
+      "type": "object",
+      "description": "YAML anchors and variable definitions for reuse throughout the scenario"
+    },
     "seed": {
       "type": "integer",
       "description": "Master seed for reproducible random operations across the scenario"

--- a/tests/test_schema_validation.py
+++ b/tests/test_schema_validation.py
@@ -124,6 +124,19 @@ workflow:
         with pytest.raises(jsonschema.ValidationError):
             jsonschema.validate(invalid_data, schema)
 
+    def test_schema_validates_vars_section(self, schema):
+        """Test that the schema validates the vars section for YAML anchors."""
+        valid_data = {
+            "vars": {
+                "default_capacity": 100,
+                "common_attrs": {"region": "datacenter1", "type": "switch"},
+            },
+            "network": {"nodes": {}, "links": []},
+        }
+
+        # Should not raise any validation errors
+        jsonschema.validate(valid_data, schema)
+
     def test_schema_validates_link_risk_groups(self, schema):
         """Test that the schema validates risk_groups in link_params."""
         valid_data = {


### PR DESCRIPTION
## `vars` - YAML Anchors and Variables

The `vars` section provides a designated space for YAML anchor definitions. YAML anchors (`&name`) and aliases (`*name`) follow the YAML 1.1 specification and are processed by PyYAML during parsing, before NetGraph validation.

**Anchor Types:**

- **Scalar anchors**: Reference primitive values (strings, numbers, booleans)
- **Sequence anchors**: Reference arrays/lists
- **Mapping anchors**: Reference objects/dictionaries
- **Merge keys (`<<`)**: Merge mapping properties with override capability

**Minimal Example:**

```yaml
vars:
  default_cap: &cap 10000
  base_attrs: &attrs {cost: 100, region: "dc1"}

network:
  nodes:
    N1: {attrs: {<<: *attrs, capacity: *cap}}
    N2: {attrs: {<<: *attrs, capacity: *cap, region: "dc2"}}
```

**Processing Behavior:**

- Anchors are resolved during YAML parsing, before schema validation
- The `vars` section itself is ignored by NetGraph runtime logic
- Anchors can be defined in any section, not just `vars`
- Merge operations follow YAML 1.1 semantics (later keys override earlier ones)