### PR TITLE
Support attribute-based node grouping

### DIFF
--- a/ngraph/network_view.py
+++ b/ngraph/network_view.py
@@ -160,10 +160,10 @@ class NetworkView:
         return cache[add_reverse]
 
     def select_node_groups_by_path(self, path: str) -> Dict[str, List["Node"]]:
-        """Select and group visible nodes matching a regex pattern.
+        """Select and group visible nodes using regex or attribute directive.
 
         Args:
-            path: Regular expression pattern to match node names.
+            path: Regular expression pattern or ``"attr:<name>"`` directive.
 
         Returns:
             Dictionary mapping group labels to lists of matching visible nodes.

--- a/tests/test_network_selection.py
+++ b/tests/test_network_selection.py
@@ -97,6 +97,21 @@ class TestNodeSelection:
         # Should have groups for each combination found
         assert len(node_groups) >= 2
 
+    def test_select_node_groups_by_attr(self):
+        """Test grouping nodes by attribute value."""
+        net = Network()
+        net.add_node(Node("r1", attrs={"metro": "SEA"}))
+        net.add_node(Node("r2", attrs={"metro": "SEA"}))
+        net.add_node(Node("r3", attrs={"metro": "SFO"}))
+
+        groups = net.select_node_groups_by_path("attr:metro")
+
+        assert set(groups) == {"SEA", "SFO"}
+        sea = {n.name for n in groups["SEA"]}
+        assert sea == {"r1", "r2"}
+        sfo = {n.name for n in groups["SFO"]}
+        assert sfo == {"r3"}
+
 
 class TestLinkUtilities:
     """Tests for link utility methods."""

--- a/tests/test_network_view.py
+++ b/tests/test_network_view.py
@@ -428,6 +428,23 @@ class TestNetworkViewSelectNodeGroups:
         # Should return empty dict since all dc1 nodes are hidden
         assert len(groups) == 0
 
+    def test_select_by_attribute(self):
+        """Test grouping visible nodes by attribute value."""
+        net = Network()
+        net.add_node(Node("a", attrs={"role": "core"}))
+        net.add_node(Node("b", attrs={"role": "core"}))
+        net.add_node(Node("c", attrs={"role": "edge"}))
+        net.nodes["b"].disabled = True
+        view = NetworkView(_base=net)
+
+        groups = view.select_node_groups_by_path("attr:role")
+
+        assert set(groups) == {"core", "edge"}
+        core = {n.name for n in groups["core"]}
+        assert core == {"a"}
+        edge = {n.name for n in groups["edge"]}
+        assert edge == {"c"}
+
 
 class TestNetworkViewEdgeCases:
     """Test NetworkView edge cases and error conditions."""


### PR DESCRIPTION
## Summary
- allow selecting node groups by attribute value using `attr:` directive
- document attribute directive in network view selection
- test attribute-based grouping for networks and views

## Testing
- `make format` *(fails: pre-commit: No such file or directory)*
- `ruff format ngraph/network.py ngraph/network_view.py tests/test_network_selection.py tests/test_network_view.py`
- `ruff check ngraph/network.py ngraph/network_view.py tests/test_network_selection.py tests/test_network_view.py --fix`
- `make docs`
- `make check` *(fails: pre-commit is not installed)*
- `pytest` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6894b36acdf0832186d9aed47ad47219